### PR TITLE
`#[derive]`に`Hash`を追加する

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -59,7 +59,7 @@ impl<T> Vectorize<T> for Option<Vec<T>> {
 }
 
 /// コードの範囲を表すもの。 usize 2 個ぶんなので Copyable.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Span {
     pub start: usize,
     pub end: usize,

--- a/src/types.rs
+++ b/src/types.rs
@@ -78,7 +78,7 @@ impl Span {
 }
 
 /// コードを line & column 形式 (0-indexed) で指定したもの。
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct LineCol {
     pub line: usize,
     pub column: usize,
@@ -86,7 +86,7 @@ pub struct LineCol {
 
 /// CST にテキストの情報を付加したもの。
 // TODO: 自己参照構造体にする。
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Hash)]
 pub struct CstText {
     pub text: String,
     pub lines: Vec<usize>,
@@ -271,7 +271,7 @@ impl Display for CstText {
 
 /// Concrete syntax tree.
 /// 1つの CST は構文規則、テキストの範囲、子要素からなり、全体として木構造をなす。
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, Hash)]
 pub struct Cst {
     /// 構文規則。
     pub rule: Rule,

--- a/src/types/rule.rs
+++ b/src/types/rule.rs
@@ -177,7 +177,7 @@ make_rule! {
     dummy_block_cmd_incomplete,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Mode {
     /// プログラムモード
     Program,


### PR DESCRIPTION
`#[derive]`に`Hash`を追加しました。

これによりHashTableなどに入れることができるようになります。