### PR TITLE
Unicode math support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ anyhow = "1.0.38"
 glob = "0.3.0"
 itertools = "0.10.0"
 log = "0.4.14"
-peg = "0.6.3"
+peg = "0.7.0"
 structopt = "0.3.21"
 thiserror = "1.0.24"
 

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -818,8 +818,10 @@ peg::parser! {
         rule math_group() -> Cst = "{" _ m:math_single() _ "}" {m} / math_unary()
 
         pub rule math_unary() -> Cst =
-            // TODO: allow unicode characters
-            s:p() ['A'..='Z' | 'a'..='z' | '0'..='9'] e:p() { cst!(math_unary (s, e) []) }
+            s:p() [^ '+' | '-' | '*' | '/' | ':' | '=' | '<' | '>' | '~' | '.' | ',' | '`' | '?' | ' ' |
+                    '\t' | '\n' | '\r' | '\\' | '{' | '}' | '%' | '|' | '$' | '#' | ';' | '\'' | '^' | '_' | '!' ] e:p() {
+                        cst!(math_unary (s, e) []) 
+            }
             / s:p() r"\" math_special_char() e:p() { cst!(math_unary (s, e) []) }
             / s:p() math_symbol() e:p() { cst!(math_unary (s, e) []) }
             / s:p() m:math_cmd() e:p() { cst!(math_unary (s, e) [m]) }


### PR DESCRIPTION
I added a Unicode math support.

According to the lexer of the original project, tokens that match following pattern is considered as `MATHCHAR`:
```ocaml
let mathstr = [^ '+' '-' '*' '/' ':' '=' '<' '>' '~' '.' ',' '`' '?' ' ' '\t' '\n' '\r' '\\' '{' '}' '%' '|' '$' '#' ';' '\'' '^' '_' '!']
```
Therefore I just copied it to this project.